### PR TITLE
feat: cache font split response

### DIFF
--- a/src/emfont.js
+++ b/src/emfont.js
@@ -142,7 +142,7 @@
          * @param {string} url See {@link fetch}
          * @param {RequestInit} options See {@link fetch}
          * @param {ReturnType<typeof this._createLocalStorageCacher>} cacher
-         * See {@link _createLocalStorageCacher}, if null, then nothing will be cached
+         * See {@link _createLocalStorageCacher}, nothing will be cached if null
          * @returns {Promise<T>}
          */
         async _fetchJson(url, options, cacher) {
@@ -158,7 +158,7 @@
 
             const responseJson = await response.json();
 
-            // 只當 status 等於 success 的時候，才進行 cache
+            // Cache only when "status" is "success"
             if ("status" in responseJson && responseJson.status !== "success") {
                 return responseJson;
             }

--- a/src/emfont.js
+++ b/src/emfont.js
@@ -1,5 +1,13 @@
 /** @format */
 
+/**
+ * @typedef {{
+ *   version: number,
+ *   payload: any,
+ *   expiresAt: string,
+ * }} EmfontCacheContent
+ */
+
 (function (root, factory) {
     if (typeof define === "function" && define.amd) {
         // AMD. Register as an anonymous module
@@ -65,6 +73,98 @@
                 root: document.documentElement,
                 ...newConfig
             };
+        }
+
+        /**
+         * Hash a string to a number
+         *
+         * @param {string} str
+         * @param {number} seed
+         * @returns {number}
+         */
+        _cyrb53(str, seed = 42) {
+            let h1 = 0xdeadbeef ^ seed,
+                h2 = 0x41c6ce57 ^ seed;
+            for (let i = 0, ch; i < str.length; i++) {
+                ch = str.charCodeAt(i);
+                h1 = Math.imul(h1 ^ ch, 2654435761);
+                h2 = Math.imul(h2 ^ ch, 1597334677);
+            }
+            h1 = Math.imul(h1 ^ (h1 >>> 16), 2246822507);
+            h1 ^= Math.imul(h2 ^ (h2 >>> 13), 3266489909);
+            h2 = Math.imul(h2 ^ (h2 >>> 16), 2246822507);
+            h2 ^= Math.imul(h1 ^ (h1 >>> 13), 3266489909);
+
+            return 4294967296 * (2097151 & h2) + (h1 >>> 0);
+        }
+
+        /**
+         * Cache a value
+         * @template T
+         * @param {string} key
+         * @param {number} ttl The cache TTL in seconds, by default it is 1 day
+         * @returns {{get: () => T | null, set: (value: T) => void}}
+         */
+        _cache(key, ttl = 86400) {
+            const version = 1;
+            const cacheKey = `emfont-cache:${key}`;
+
+            return {
+                get() {
+                    const cacheJson = localStorage.getItem(cacheKey);
+                    if (cacheJson) {
+                        /**
+                         * @type {EmfontCacheContent}
+                         */
+                        const cache = JSON.parse(cacheJson);
+                        if (cache.version === version && new Date(cache.expiresAt) > new Date()) {
+                            return cache.payload;
+                        }
+                    }
+
+                    return null;
+                },
+                set(value) {
+                    /**
+                     * @type {EmfontCacheContent}
+                     */
+                    const cache = {
+                        version,
+                        payload: value,
+                        expiresAt: new Date(Date.now() + ttl * 1000).toISOString()
+                    };
+                    localStorage.setItem(cacheKey, JSON.stringify(cache));
+                }
+            };
+        }
+
+        /**
+         * Fetch JSON with cache
+         * @template T
+         * @param {string} url See {@link fetch}
+         * @param {RequestInit} options See {@link fetch}
+         * @param {{get: () => T, set: (value: T) => void}} cacher
+         * See {@link _cache}, if null, then nothing will be cached
+         * @returns {Promise<T>}
+         */
+        async _fetchJson(url, options, cacher) {
+            const cache = cacher?.get();
+            if (cache) {
+                return cache;
+            }
+
+            const response = await fetch(url, options);
+            if (!response.ok) throw new Error(`HTTP error ${response.status}`);
+
+            const responseJson = await response.json();
+
+            // 只當 status 等於 success 的時候，才進行 cache
+            if ("status" in responseJson && responseJson.status !== "success") {
+                return responseJson;
+            }
+
+            cacher?.set(responseJson);
+            return responseJson;
         }
 
         init(newConfig = {}) {
@@ -166,6 +266,7 @@
                         this.fonts[fontName] = newFonts[fontName];
                     }
                 });
+
                 const fetchPromises = Object.entries(newFonts).map(([fontName, words]) => {
                     let postFontName = fontName;
                     const min = this.config.forceMin || fontName.includes("-min");
@@ -176,22 +277,27 @@
                         weight = weight[1];
                     }
                     const tofu = this.config.tofu ? ", 'Tofu'" : "";
-                    return fetch("{{BASE_URL}}/g/" + postFontName, {
-                        method: "POST",
-                        headers: {
-                            "Content-Type": "application/json"
+
+                    const payload = JSON.stringify({
+                        words: words + " ",
+                        min,
+                        weight,
+                        format: this.config.format
+                    });
+                    const payloadHash = this._cyrb53(payload);
+                    const cacher = !min && this.config.cache ? this._cache(payloadHash, 86400) : null;
+
+                    return this._fetchJson(
+                        "{{BASE_URL}}/g/" + postFontName,
+                        {
+                            method: "POST",
+                            headers: {
+                                "Content-Type": "application/json"
+                            },
+                            body: payload,
                         },
-                        body: JSON.stringify({
-                            words: words + " ",
-                            min,
-                            weight,
-                            format: this.config.format
-                        })
-                    })
-                        .then(response => {
-                            if (!response.ok) throw new Error(`HTTP error ${response.status}`);
-                            return response.json();
-                        })
+                        cacher
+                    )
                         .then(async data => {
                             if (data.status === "success") {
                                 if (data.message) console.warn("✏️ " + data.message);

--- a/src/emfont.js
+++ b/src/emfont.js
@@ -2,7 +2,7 @@
 
 /**
  * @typedef {{
- *   version: number,
+ *   version: string,
  *   payload: any,
  *   expiresAt: string,
  * }} EmfontCacheContent
@@ -104,7 +104,7 @@
          * @returns {{get: (key: string) => T | null, set: (key: string, value: T) => void}}
          */
         _createLocalStorageCacher(ttl = 86400) {
-            const version = 1;
+            const version = "{{FONT_VERSION}}";
             const cachePrefix = "emfont-cache:";
 
             return {

--- a/src/emfont.js
+++ b/src/emfont.js
@@ -77,7 +77,6 @@
 
         /**
          * Hash a string to a number
-         *
          * @param {string} str
          * @param {number} seed
          * @returns {number}
@@ -101,17 +100,16 @@
         /**
          * Cache a value
          * @template T
-         * @param {string} key
          * @param {number} ttl The cache TTL in seconds, by default it is 1 day
-         * @returns {{get: () => T | null, set: (value: T) => void}}
+         * @returns {{get: (key: string) => T | null, set: (key: string, value: T) => void}}
          */
-        _cache(key, ttl = 86400) {
+        _createLocalStorageCacher(ttl = 86400) {
             const version = 1;
-            const cacheKey = `emfont-cache:${key}`;
+            const cachePrefix = "emfont-cache:";
 
             return {
-                get() {
-                    const cacheJson = localStorage.getItem(cacheKey);
+                get(key) {
+                    const cacheJson = localStorage.getItem(cachePrefix + key);
                     if (cacheJson) {
                         /**
                          * @type {EmfontCacheContent}
@@ -124,7 +122,7 @@
 
                     return null;
                 },
-                set(value) {
+                set(key, value) {
                     /**
                      * @type {EmfontCacheContent}
                      */
@@ -133,7 +131,7 @@
                         payload: value,
                         expiresAt: new Date(Date.now() + ttl * 1000).toISOString()
                     };
-                    localStorage.setItem(cacheKey, JSON.stringify(cache));
+                    localStorage.setItem(cachePrefix + key, JSON.stringify(cache));
                 }
             };
         }
@@ -143,12 +141,14 @@
          * @template T
          * @param {string} url See {@link fetch}
          * @param {RequestInit} options See {@link fetch}
-         * @param {{get: () => T, set: (value: T) => void}} cacher
-         * See {@link _cache}, if null, then nothing will be cached
+         * @param {ReturnType<typeof this._createLocalStorageCacher>} cacher
+         * See {@link _createLocalStorageCacher}, if null, then nothing will be cached
          * @returns {Promise<T>}
          */
         async _fetchJson(url, options, cacher) {
-            const cache = cacher?.get();
+            const cacheKey = this._cyrb53(url + JSON.stringify(options));
+
+            const cache = cacher?.get(cacheKey);
             if (cache) {
                 return cache;
             }
@@ -163,7 +163,7 @@
                 return responseJson;
             }
 
-            cacher?.set(responseJson);
+            cacher?.set(cacheKey, responseJson);
             return responseJson;
         }
 
@@ -278,14 +278,7 @@
                     }
                     const tofu = this.config.tofu ? ", 'Tofu'" : "";
 
-                    const payload = JSON.stringify({
-                        words: words + " ",
-                        min,
-                        weight,
-                        format: this.config.format
-                    });
-                    const payloadHash = this._cyrb53(payload);
-                    const cacher = !min && this.config.cache ? this._cache(payloadHash, 86400) : null;
+                    const cacher = !min && this.config.cache ? this._createLocalStorageCacher(86400) : null;
 
                     return this._fetchJson(
                         "{{BASE_URL}}/g/" + postFontName,
@@ -294,7 +287,12 @@
                             headers: {
                                 "Content-Type": "application/json"
                             },
-                            body: payload,
+                            body: JSON.stringify({
+                                words: words + " ",
+                                min,
+                                weight,
+                                format: this.config.format
+                            })
                         },
                         cacher
                     )


### PR DESCRIPTION
快取會被存在 localStorage，且只會在 options 中 `cache` 等於 true，且未開啟極致壓縮的情況下動作：

<img width="2606" height="752" alt="CleanShot 2025-08-03 at 23 20 56@2x" src="https://github.com/user-attachments/assets/a487ee34-2d05-401d-9ce0-ae64ae26a26c" />

可以把下載字體的總時長從 1000ms 以上縮到不到 300ms:

<img width="2502" height="688" alt="CleanShot 2025-08-03 at 23 21 32@2x" src="https://github.com/user-attachments/assets/722f2eb4-04ea-4f87-8a3e-80dbe1567ae2" />

預設 TTL 是 1 天，如果超過 1 天的話會自動 Invalidate。
另外 emfont 端如果做了任何改動，也可以透過更改 emfont.js 中的 `version` 來手動 invalidate 掉老快取。